### PR TITLE
Call initCam on pjax success

### DIFF
--- a/js/app.coffee
+++ b/js/app.coffee
@@ -68,13 +68,14 @@ WMTU.initStream = ->
     WMTU.onStreamPause()
 
 WMTU.initCam = ->
-  jwplayer.key="QOM8nBM9YblVTd5FdhWTW9bYOmkMd0CmACOrA1+gZeE="
-  jwplayer("live-video").setup
-    file: "{{ site.cam_url }}",
-    height: 450,
-    width: 800,
-    autostart: false,
-    androidhls: true
+  if $("#live-video").length
+    jwplayer.key="QOM8nBM9YblVTd5FdhWTW9bYOmkMd0CmACOrA1+gZeE="
+    jwplayer("live-video").setup
+      file: "{{ site.cam_url }}",
+      height: 450,
+      width: 800,
+      autostart: false,
+      androidhls: true
 
 WMTU.bindThings = ->
   $("#play-button").click ->
@@ -130,3 +131,4 @@ $(document).ready ->
 $(document).on "pjax:success", (event)->
   $("body *").off();
   WMTU.bindThings()
+  WMTU.initCam()


### PR DESCRIPTION
Add a call to initCam on pjax success; in initCam, verify element with ID `live-video` exists before attempting to load the player
